### PR TITLE
using sync.Map to resolve issue #16

### DIFF
--- a/response.go
+++ b/response.go
@@ -47,14 +47,18 @@ func marshalResponse(msg []byte) (resp response, err error) {
 // saveResponse makes the response available for retrieval by the requester. Mutexes are used for thread safety.
 func (c *Client) saveResponse(resp response) {
 	c.respMutex.Lock()
-	container := c.results[resp.requestid]  // Retrieve old data container (for requests with multiple responses)
-	newdata := append(container, resp.data) // Create new data container with new data
-	c.results[resp.requestid] = newdata     // Add new data to buffer for future retrieval
+	var container []interface{}
+	existingData, ok := c.results.Load(resp.requestid) // Retrieve old data container (for requests with multiple responses)
+	if ok {
+		container = existingData.([]interface{})
+	}
+	newdata := append(container, resp.data)  // Create new data container with new data
+	c.results.Store(resp.requestid, newdata) // Add new data to buffer for future retrieval
 	if resp.code == 200 || resp.code == 204 {
-		if c.responseNotifyer[resp.requestid] == nil {
-			c.responseNotifyer[resp.requestid] = make(chan int, 1)
+		respNofifier, loaded := c.responseNotifyer.LoadOrStore(resp.requestid, make(chan int, 1))
+		if loaded {
+			respNofifier.(chan int) <- 1
 		}
-		c.responseNotifyer[resp.requestid] <- 1
 	}
 	c.respMutex.Unlock()
 	return
@@ -62,19 +66,22 @@ func (c *Client) saveResponse(resp response) {
 
 // retrieveResponse retrieves the response saved by saveResponse.
 func (c *Client) retrieveResponse(id string) (data []interface{}) {
-	n := <-c.responseNotifyer[id]
+	resp, _ := c.responseNotifyer.Load(id)
+	n := <-resp.(chan int)
 	if n == 1 {
-		data = c.results[id]
-		close(c.responseNotifyer[id])
-		delete(c.responseNotifyer, id)
-		c.deleteResponse(id)
+		if dataI, ok := c.results.Load(id); ok {
+			data = dataI.([]interface{})
+			close(resp.(chan int))
+			c.responseNotifyer.Delete(id)
+			c.deleteResponse(id)
+		}
 	}
 	return
 }
 
 // deleteRespones deletes the response from the container. Used for cleanup purposes by requester.
 func (c *Client) deleteResponse(id string) {
-	delete(c.results, id)
+	c.results.Delete(id)
 	return
 }
 

--- a/response.go
+++ b/response.go
@@ -55,10 +55,8 @@ func (c *Client) saveResponse(resp response) {
 	newdata := append(container, resp.data)  // Create new data container with new data
 	c.results.Store(resp.requestid, newdata) // Add new data to buffer for future retrieval
 	if resp.code == 200 || resp.code == 204 {
-		respNofifier, loaded := c.responseNotifyer.LoadOrStore(resp.requestid, make(chan int, 1))
-		if loaded {
-			respNofifier.(chan int) <- 1
-		}
+		respNofifier, _ := c.responseNotifyer.LoadOrStore(resp.requestid, make(chan int, 1))
+		respNofifier.(chan int) <- 1
 	}
 	c.respMutex.Unlock()
 	return

--- a/response_test.go
+++ b/response_test.go
@@ -85,7 +85,8 @@ func TestResponseSortingSingleResponse(t *testing.T) {
 	var expected []interface{}
 	expected = append(expected, dummySuccessfulResponseMarshalled.data)
 
-	if reflect.DeepEqual(c.results[dummySuccessfulResponseMarshalled.requestid], expected) != true {
+	result, _ := c.results.Load(dummySuccessfulResponseMarshalled.requestid)
+	if reflect.DeepEqual(result.([]interface{}), expected) != true {
 		t.Fail()
 	}
 }
@@ -102,7 +103,8 @@ func TestResponseSortingMultipleResponse(t *testing.T) {
 	expected = append(expected, dummyPartialResponse1Marshalled.data)
 	expected = append(expected, dummyPartialResponse2Marshalled.data)
 
-	if reflect.DeepEqual(c.results[dummyPartialResponse1Marshalled.requestid], expected) != true {
+	results, _ := c.results.Load(dummyPartialResponse1Marshalled.requestid)
+	if reflect.DeepEqual(results.([]interface{}), expected) != true {
 		t.Fail()
 	}
 }
@@ -134,7 +136,7 @@ func TestResponseDeletion(t *testing.T) {
 
 	c.deleteResponse(dummyPartialResponse1Marshalled.requestid)
 
-	if len(c.results[dummyPartialResponse1Marshalled.requestid]) != 0 {
+	if _, ok := c.results.Load(dummyPartialResponse1Marshalled.requestid); ok {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
Both results and responseNotifyer were not being used in a go routine safe way, causing issues when trying to scale.

I've used sync.Map to resolve the problem, we are running with 10 concurrent go routines without an issue.