### PR TITLE
Update interface to allow close() to return an error

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -12,7 +12,7 @@ type dialer interface {
 	connect() error
 	write([]byte) error
 	read() ([]byte, error)
-	close()
+	close() error
 }
 
 /////


### PR DESCRIPTION
Looks like I missed this as part of https://github.com/qasaur/gremgo/pull/23