### PR TITLE
Take 2-arg uuid.NewV4() in prepareRequest()

### DIFF
--- a/request.go
+++ b/request.go
@@ -29,7 +29,12 @@ type request struct {
 
 // prepareRequest packages a query and binding into the format that Gremlin Server accepts
 func prepareRequest(query string, bindings, rebindings map[string]string) (req request, id string, err error) {
-	id = uuid.NewV4().String()
+	var uuID uuid.UUID
+        uuID, err = uuid.NewV4()
+        if err != nil {
+                return
+        }
+        id = uuID.String()
 
 	req.RequestId = id
 	req.Op = "eval"


### PR DESCRIPTION
Fix for #38.

`uuid.NewV4()` returns a `UUID` and an `error` but `prepareRequest` was only receiving one argument.

This change receives the error and bails out if it's not nil.